### PR TITLE
Changed localhost to location.hostname.

### DIFF
--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -1,5 +1,5 @@
 angular.module('2gather').factory('Transaction', function($http, $q) {
-    var baseUrl = 'http://localhost:3000/apis/2gather'; //url to poll transactions
+    var baseUrl = 'http://'+location.hostname+':3000/apis/2gather'; //url to poll transactions
     var timeoutConfig = 5000; //in milliseconds
 
     function pollTransactionState(transactionHash) {


### PR DESCRIPTION
Doesn't work if 'localhost' on OS X (due to boot2docker).

EDIT:

To clarify. It's because if on OS X, it connects to the boot2docker VM, which is accessed from that VM's IP. Thus, 'localhost' shouldn't be hardcoded.