### PR TITLE
Fix for video POST routes

### DIFF
--- a/models/2gather.js
+++ b/models/2gather.js
@@ -6,11 +6,11 @@ function TwoGather() {
 	tgApi = new TwoGatherAPI();
 
 	// Used to handle all incoming requests. It is set as the callback for
-	// incominghttp requests. It parses the request URL into an object, then 
+	// incominghttp requests. It parses the request URL into an object, then
 	// pass that object into the appropriate sub handler (should one exist).
 	// Sub handlers needs to return a response object.
 	this.handle = function(httpReq) {
-		
+
 		Println("Receiving");
 		var urlObj = network.parseUrl(httpReq);
 		// Error 400 bad request
@@ -34,7 +34,7 @@ function TwoGather() {
 		}
 		return resp;
 	}
-	
+
 	// Handle user requests. Warning! - Very sophisticated routing algorithm at work.
 	handlers.user = function(urlObj,httpReq){
 		var path = urlObj.path;
@@ -50,21 +50,25 @@ function TwoGather() {
 			} else if (path[2] === "subs"){
 				Println("Sub request");
 				return doSub("",httpReq.Method,httpReq.Body);
+			} else {
+				return network.getHttpResponse(400,{},"Bad request: malformed URL");
 			}
 		} else if (path.length == 4){
 			if(path[2] === "videos"){
 				return doVideo(path[1],path[3],httpReq.Method,httpReq.Body);
 			} else if (path[2] === "subs"){
 				return doSub(path[3],httpReq.Method,httpReq.Body);
+			} else {
+				return network.getHttpResponse(400,{},"Bad request: malformed URL");
 			}
 		} else {
 			return network.getHttpResponse(400,{},"Bad request: malformed URL");
 		}
 	}
-	
+
 	handlers.txs = function(urlObj, httpReq) {
 		Println("Getting tx");
-		if(httpReq.Method === "GET") {			
+		if(httpReq.Method === "GET") {
 			if(urlObj.path.length !== 2){
 				return network.getHttpResponse(400,{},"Bad request: invalid path.");
 			}
@@ -102,7 +106,7 @@ function TwoGather() {
 
 	handlers.session = function(urlObj, httpReq) {
 		Println("Getting session.");
-		if(httpReq.Method === "GET") {			
+		if(httpReq.Method === "GET") {
 			if(urlObj.path.length !== 1){
 				return network.getHttpResponse(400,{},"Bad request: invalid path.");
 			}
@@ -260,7 +264,7 @@ function TwoGather() {
 					if(patch.op === "replace"){
 						txHashes[i] = tgApi.blacklistById(username, videoId);
 					} else {
-						return network.getHttpResponse(501,{},"Not yet supported - Blacklisting can't be undone.");	
+						return network.getHttpResponse(501,{},"Not yet supported - Blacklisting can't be undone.");
 					}
 				} else if (patch.field === "flag"){
 					if(patch.op === "replace"){

--- a/scripts/2gather.js
+++ b/scripts/2gather.js
@@ -68,9 +68,9 @@ angular.module('2gather', ['ngRoute', 'tgAnimations', 'naif.base64'])
 
     $scope.uploadVideo = function(video){
       var username = $scope.user.user_name;
-      Transaction('POST', 'user/' + username + '/video', {
+      Transaction('POST', 'user/' + username + '/videos', {
         name: video.name,
-        data: video.file.base64
+        base64: video.file.base64
       }).then(function(){
         console.log('video uploaded')
       });

--- a/spec/API_specification.md
+++ b/spec/API_specification.md
@@ -198,7 +198,7 @@ This causes the active user to unsubscribe to the target user. The target must b
 
 ### Resource: user.video
 
-#### POST `{base-URL}user/:username/video` (tx)
+#### POST `{base-URL}user/:username/videos` (tx)
 
 Uploads a video.
 
@@ -211,7 +211,7 @@ Request Body:
 }
 ```
 
-#### PATCH `{base-URL}/user/:username/video/:id` (tx)
+#### PATCH `{base-URL}/user/:username/videos/:id` (tx)
 
 Modify a video. A user can only modify their own videos via the current user. Any attempt to modify someone else’s videos will fail at the contract level.
 
@@ -222,7 +222,7 @@ Fields available to PATCH for the `user` resource:
 * `flag` Boolean
 * `blacklist` Boolean
 
-#### DELETE `{base-URL}/user/:username/video/:id` (tx)
+#### DELETE `{base-URL}/user/:username/videos/:id` (tx)
 
 Remove a video. The owner name has to be tied to the users thelonious address. If you try to remove some other users videos it’ll just fail. Here in case we add admin rights to remove.
 


### PR DESCRIPTION
fixes:

* update spec to properly use `videos` instead of `video` which is what the router is looking for
* add 404 return to the `videos` end point in the router function
* update frontend to reference the end point properly