### PR TITLE
Adapt jq command so it's compatible with jq v1.1

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -41,7 +41,7 @@ echo "root_contract ($root_contract)."
 
 mv package.json /tmp/
 
-jq '.module_dependencies[0].data |= . * {blockchain_id: "'$blockchain_id'", root_contract: "'$root_contract'"}' /tmp/package.json \
+jq '.module_dependencies[0].data |= . + {blockchain_id: "'$blockchain_id'", root_contract: "'$root_contract'"}' /tmp/package.json \
   > package.json
 
 # put the 2gather DApp in focus


### PR DESCRIPTION
The fact that issue https://github.com/eris-ltd/2gather/issues/56 occurred in Ubuntu 14.04 and not in other systems turned out to be a version difference of the `jq` tool.

The version included in Ubuntu 14.04 is 1.1. This version throws an error when using the operator `. *` in the situation as used in `start.sh`. The latest version, 1.4, runs without error and delivers the desired result.

When using the operator `. +` per this pull request, the result is the same in both `jq` 1.1 and 1.4: the values of `blockchain_id` and `root_contract` under `module_dependencies/data` are replaced and other values in that node are preserved.
